### PR TITLE
Pipeline build on Windows 2022 with new vs path

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
       bash prep.sh
     displayName: Prep Build
   - script: |
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       cd bochs
       bash .conf.cpu-msvc
       nmake


### PR DESCRIPTION
`windows-latest` now uses Windows 2022 which has a different [Visual Studio install](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md#visual-studio-enterprise-2022)

- failing run: https://dev.azure.com/considerthelion/pipeline/_build/results?buildId=18&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=f33089cd-d3fe-578c-2c5e-4ee560e10a0d&l=12
- new succeeding run: https://dev.azure.com/considerthelion/pipeline/_build/results?buildId=26&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=f33089cd-d3fe-578c-2c5e-4ee560e10a0d