### PR TITLE
Fix `rdrand` patch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.patch eol=lf
+* text=auto

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  bochscpu:
+    env:
+      NB_CPU: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - {os: windows-latest, arch: x64}
+          - {os: ubuntu-latest, arch: x64}
+          - {os: macos-latest, arch: x64}
+    runs-on: ${{ matrix.variant.os }}
+    name: ${{ matrix.variant.os }} / ${{ matrix.variant.arch }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Initialization (Windows)
+      if: matrix.variant.os == 'windows-latest'
+      run: echo "NB_CPU=$env:NUMBER_OF_PROCESSORS" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: Initialization (Linux)
+      if: matrix.variant.os == 'ubuntu-latest'
+      run: echo "NB_CPU=$(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+
+    - name: Initialization (MacOS)
+      if: matrix.variant.os == 'macos-latest'
+      run: echo "NB_CPU=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
+
+    - uses: microsoft/setup-msbuild@v1
+      if: matrix.variant.os == 'windows-latest'
+
+    - uses: ilammy/msvc-dev-cmd@v1
+      if: matrix.variant.os == 'windows-latest'
+
+    - name: Build BochsCPU (Windows)
+      if: matrix.variant.os == 'windows-latest'
+      shell: powershell
+      run: |
+        bash -c 'sh prep.sh; cd Bochs/bochs; sh .conf.cpu-msvc;'
+        cd Bochs/bochs
+        Start-Process nmake -ErrorAction SilentlyContinue -PassThru -Wait
+        cd ../..
+        mkdir lib
+        cp -Verbose Bochs/bochs/cpu/libcpu.a lib/cpu.a
+        cp -Verbose Bochs/bochs/cpu/fpu/libfpu.a lib/fpu.a
+        cp -Verbose Bochs/bochs/cpu/avx/libavx.a lib/avx.a
+        cp -Verbose Bochs/bochs/cpu/cpudb/libcpudb.a lib/cpudb.a
+
+    - name: Build BochsCPU (Linux & MacOS)
+      if: matrix.variant.os != 'windows-latest'
+      shell: bash
+      run: |
+        sh prep.sh
+        cd Bochs/bochs
+        sh .conf.cpu
+        make -j ${{ env.NB_CPU }} || true
+        cd ../..
+        mkdir lib
+        cp -v Bochs/bochs/cpu/libcpu.a lib/
+        cp -v Bochs/bochs/cpu/fpu/libfpu.a lib/
+        cp -v Bochs/bochs/cpu/avx/libavx.a lib/
+        cp -v Bochs/bochs/cpu/cpudb/libcpudb.a lib/
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: bochscpu-build-${{ matrix.variant.os }}-${{ matrix.variant.arch }}
+        path: lib

--- a/patches/0000-rdrand.patch
+++ b/patches/0000-rdrand.patch
@@ -1,111 +1,18 @@
 diff --git a/bochs/cpu/rdrand.cc b/bochs/cpu/rdrand.cc
-index 1b787d4..e9171da 100644
+index cb26678fd..1438f43db 100644
 --- a/bochs/cpu/rdrand.cc
 +++ b/bochs/cpu/rdrand.cc
-@@ -29,6 +29,8 @@
- 
- #define HW_RANDOM_GENERATOR_READY (1)
- 
+@@ -34,10 +34,12 @@ bool hw_rand_ready()
+   return HW_RANDOM_GENERATOR_READY;
+ }
+
 +extern "C" Bit64u bochscpu_rand(unsigned);
 +
- void BX_CPP_AttrRegparmN(1) BX_CPU_C::RDRAND_Ew(bxInstruction_c *i)
+ // provide a byte of data from Hardware Random Generator (TBD: implement as device)
+ Bit8u hw_rand8()
  {
- #if BX_SUPPORT_VMX
-@@ -44,9 +46,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::RDRAND_Ew(bxInstruction_c *i)
-   clearEFlagsOSZAPC();
- 
-   if (HW_RANDOM_GENERATOR_READY) {
--    val_16 |= rand() & 0xff;  // hack using std C rand() function
--    val_16 <<= 8;
--    val_16 |= rand() & 0xff;
-+    val_16 |= (Bit16u)bochscpu_rand(BX_CPU_ID);
- 
-     assert_CF();
-   }
-@@ -71,13 +71,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::RDRAND_Ed(bxInstruction_c *i)
-   clearEFlagsOSZAPC();
- 
-   if (HW_RANDOM_GENERATOR_READY) {
--    val_32 |= rand() & 0xff;  // hack using std C rand() function
--    val_32 <<= 8;
--    val_32 |= rand() & 0xff;
--    val_32 <<= 8;
--    val_32 |= rand() & 0xff;
--    val_32 <<= 8;
--    val_32 |= rand() & 0xff;
-+    val_32 |= (Bit32u)bochscpu_rand(BX_CPU_ID);
- 
-     assert_CF();
-   }
-@@ -103,21 +97,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::RDRAND_Eq(bxInstruction_c *i)
-   clearEFlagsOSZAPC();
- 
-   if (HW_RANDOM_GENERATOR_READY) {
--    val_64 |= rand() & 0xff;  // hack using std C rand() function
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
-+    val_64 |= bochscpu_rand(BX_CPU_ID);
- 
-     assert_CF();
-   }
-@@ -143,9 +123,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::RDSEED_Ew(bxInstruction_c *i)
-   clearEFlagsOSZAPC();
- 
-   if (HW_RANDOM_GENERATOR_READY) {
--    val_16 |= rand() & 0xff;  // hack using std C rand() function
--    val_16 <<= 8;
--    val_16 |= rand() & 0xff;
-+    val_16 |= (Bit16u)bochscpu_rand(BX_CPU_ID);
- 
-     assert_CF();
-   }
-@@ -170,13 +148,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::RDSEED_Ed(bxInstruction_c *i)
-   clearEFlagsOSZAPC();
- 
-   if (HW_RANDOM_GENERATOR_READY) {
--    val_32 |= rand() & 0xff;  // hack using std C rand() function
--    val_32 <<= 8;
--    val_32 |= rand() & 0xff;
--    val_32 <<= 8;
--    val_32 |= rand() & 0xff;
--    val_32 <<= 8;
--    val_32 |= rand() & 0xff;
-+    val_32 |= (Bit32u)bochscpu_rand(BX_CPU_ID);
- 
-     assert_CF();
-   }
-@@ -202,21 +174,7 @@ void BX_CPP_AttrRegparmN(1) BX_CPU_C::RDSEED_Eq(bxInstruction_c *i)
-   clearEFlagsOSZAPC();
- 
-   if (HW_RANDOM_GENERATOR_READY) {
--    val_64 |= rand() & 0xff;  // hack using std C rand() function
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
--    val_64 <<= 8;
--    val_64 |= rand() & 0xff;
-+    val_64 |= bochscpu_rand(BX_CPU_ID);
- 
-     assert_CF();
-   }
+-  return rand() & 0xff;     // hack using std C rand() function
++  return bochscpu_rand(BX_CPU_ID) & 0xff;     // hack using std C rand() function
+ }
+
+ // provide a 16-bit of data from Hardware Random Generator (TBD: implement as device)


### PR DESCRIPTION
Hey man 👋 

Last night I encountered a problem while building bochscpu. It seems a recent merge (bochs-emu/bochs@788636910233c2d7d9660bc469aef9149ea67dae) introduced changes in `bochs/cpu/rdrand.cc` causing the `git apply` to fail. This PR fixes this so `prep.sh` works again as intended.

Note: the fix attempts to make the smallest change to rdrand.cc on purpose as it seems bochs team will be working more on it soon, having a smaller change reduces the chance it'll fail in the future IMO

Thanks again for building up this awesome project.

Cheers 🍻
