### PR TITLE
ci: fix CI on macOS by only making needed targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         BOCHS_REV=$(cat BOCHS_REV) sh prep.sh
         cd Bochs/bochs
         sh .conf.cpu
-        make -j ${{ env.NB_CPU }} || true
+        make -j ${{ env.NB_CPU }} cpu/libcpu.a cpu/fpu/libfpu.a cpu/avx/libavx.a cpu/cpudb/libcpudb.a cpu/softfloat3e/libsoftfloat.a
         cp -v cpu/libcpu.a ../../artifact/lib/
         cp -v cpu/fpu/libfpu.a ../../artifact/lib/
         cp -v cpu/avx/libavx.a ../../artifact/lib/


### PR DESCRIPTION
This is to get CI working on macOS. The needed static libraries builded just fine, but `make` might error out early depending on the order in which other targets are built.